### PR TITLE
Export Component Defs from App Build

### DIFF
--- a/.github/workflows/export-cd.yml
+++ b/.github/workflows/export-cd.yml
@@ -1,0 +1,30 @@
+name: Export Component Definition From Build
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Regenerate content
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install Trestle
+        run: make trestle-install
+      - name: Export component-definition
+        run: make exportcd
+      - name: Regenerate component-definitions
+        run: make regenerate-cd
+      - name: Update and PR
+        run: bash ./automation/lib/update.sh "Export CD from Build"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,10 @@ assemble: assemble-catalogs assemble-profiles assemble-cd assemble-ssps
 sanity: sanity-catalogs sanity-profiles sanity-cd sanity-ssps
 .PHONY: sanity
 
+exportcd:
+	source ./automation/lib/export-cd.sh && export-cd
+.PHONY: exportcd
+
 
 
 

--- a/automation/lib/export-cd.sh
+++ b/automation/lib/export-cd.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+source ./automation/lib/logging.sh
+
+export NSDATE=$(date --rfc-3339=ns | sed 's/ /T/; s/\(\....\).*\([+-]\)/\1\2/g')
+export CDDIR="component-definitions/hello-world-$GITHUB_REF_NAME"
+
+function export-cd () {
+      mkdir -p $CDDIR
+      envsubst < hello-world/hello-world-cd.json > $CDDIR/component-definition.json
+}

--- a/hello-world/go.mod
+++ b/hello-world/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/hello-world
+
+go 1.18

--- a/hello-world/hello-world-cd.json
+++ b/hello-world/hello-world-cd.json
@@ -1,0 +1,52 @@
+{
+    "component-definition": {
+      "uuid": "ded50cf2-0d03-462e-9551-ee22266af477",
+      "metadata": {
+        "title": "Hello World Component Definition",
+        "last-modified": "$NSDATE",
+        "version": "$GITHUB_REF_NAME",
+        "oscal-version": "1.0.0",
+        "roles": [
+          {
+            "id": "provider",
+            "title": "Provider"
+          }
+        ],
+        "parties": [
+          {
+            "uuid": "ef7c799a-c50e-49ab-83e0-515e989e6df1",
+            "type": "organization",
+            "name": "Acme Inc.",
+            "links": [
+              {
+                "href": "https://www.example.com",
+                "rel": "website"
+              }
+            ]
+          }
+        ]
+      },
+      "components": [
+        {
+          "uuid": "4be43b22-e9cf-46a4-a0d6-baad0d4e7045",
+          "type": "software",
+          "title": "Hello World",
+          "description": "Hello World Application",
+          "props": [
+            {
+              "name": "Rule_Id",
+              "ns": "http://ibm.github.io/compliance-trestle/schemas/oscal/cd",
+              "value": "test-rule",
+              "remarks": "rule_set_000"
+            },
+            {
+              "name": "Rule_Description",
+              "ns": "http://ibm.github.io/compliance-trestle/schemas/oscal/cd",
+              "value": "This is a rule used for testing compliance workflows",
+              "remarks": "rule_set_000"
+            }
+          ]
+        }
+      ]  
+    }
+}

--- a/hello-world/hello-world.go
+++ b/hello-world/hello-world.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var version = "dev"
+
+func main() {
+	fmt.Println("hello world, github! (", version, runtime.GOOS, runtime.GOARCH, ")")
+}


### PR DESCRIPTION
This demonstrates how OSCAL Component Definitions can be automatically updated and exported from an application build pipeline to a trestle workspace. 

To test this PR: 
1. Enable GH Actions PR creation and approval in settings
2. Tag a commit and push it to GH
3. When action completes, browse to new draft PR that was created from action
4. Identify component definition `component-definitions/hello-world-<tag Name>/component-definition.json
6. Metadata field in CD will have updated timestamp and version (matches tag)

Issues with this PR:

1. Draft PR has entire commit history of repo. 