### PR TITLE
Enable commands to be run inside trestle-demo image

### DIFF
--- a/automation/assemble.sh
+++ b/automation/assemble.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ./automation/logging.sh
+source ./automation/trestle.sh
 
 assemble_catalogs() {
 version_tag=$1

--- a/automation/import.sh
+++ b/automation/import.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 source ./automation/logging.sh
+source ./automation/trestle.sh
 
 check_trestle () {
     if ! which trestle &>/dev/null
     then
-      run_log 1 "trestle not found"
+      run_log 1 "trestle not found, try running 'make demo-build' first"
     fi
 }
 

--- a/automation/mk/custom.mk
+++ b/automation/mk/custom.mk
@@ -3,5 +3,5 @@
 ############################################################################
 
 generate-custom-ssp:
-	trestle author ssp-generate -p ACME_internal_profile --compdefs hello-world-custom -o markdown/system-security-plans/acme_custom_demo_ssp -f
+	@source ./automation/trestle.sh && trestle author ssp-generate -p ACME_internal_profile --compdefs hello-world-custom -o markdown/system-security-plans/acme_custom_demo_ssp -f
 .PHONY: generate-custom-ssp

--- a/automation/mk/fedramp.mk
+++ b/automation/mk/fedramp.mk
@@ -26,40 +26,40 @@ bootstrap-workspace: import-fedramp
 ### Generate OSCAL SSP based on FedRAMP profile
 ############################################################################
 generate-fedramp-ssp:
-	trestle author ssp-generate -p fedramp_rev4_moderate --compdefs hello-world-fedramp -o markdown/system-security-plans/acme_fedramp_demo_ssp -y extra/extra-ssp-metadata.yml -f
+	@source ./automation/trestle.sh && trestle author ssp-generate -p fedramp_rev4_moderate --compdefs hello-world-fedramp -o markdown/system-security-plans/acme_fedramp_demo_ssp -y extra/extra-ssp-metadata.yml -f
 .PHONY: generate-fedramp-ssp
 
 ############################################################################
 ### Generate single markdown file from Jinja template from OSCAL SSP
 ############################################################################
 generate-ssp-markdown: generate-details
-	trestle author jinja -i templates/ssp_md_template.md.jinja -ssp acme_fedramp_demo_ssp -p fedramp_rev4_moderate -o acme_fedramp_demo_ssp.md
+	@source ./automation/trestle.sh && trestle author jinja -i templates/ssp_md_template.md.jinja -ssp acme_fedramp_demo_ssp -p fedramp_rev4_moderate -o acme_fedramp_demo_ssp.md
 .PHONY: generate-ssp-markdown
 
 ############################################################################
 ### Run full workflow to populate FedRAMP docx template
 ############################################################################
 generate-ssp-word: generate-ssp-markdown
-	pandoc acme_fedramp_demo_ssp.md --from markdown+table_captions+implicit_figures+rebase_relative_paths -t docx --reference-doc templates/FedRAMP-SSP-Moderate-Baseline-Template.docx -s --toc -o acme_fedramp_demo_ssp.docx
+	@source ./automation/trestle.sh && pandoc acme_fedramp_demo_ssp.md --from markdown+table_captions+implicit_figures+rebase_relative_paths -t docx --reference-doc templates/FedRAMP-SSP-Moderate-Baseline-Template.docx -s --toc -o acme_fedramp_demo_ssp.docx
 .PHONY: generate-ssp-word
 
 ############################################################################
 ### Run full workflow to populate FedRAMP docx template
 ############################################################################
 generate-details: generate-fedramp-ssp
-	@./automation/ssp-to-markdown/ssp_to_markdown.py --trestle_root . --ssp_name acme_fedramp_demo_ssp > templates/details.md
+	@source ./automation/trestle.sh && python ./automation/ssp-to-markdown/ssp_to_markdown.py --trestle_root . --ssp_name acme_fedramp_demo_ssp > templates/details.md
 .PHONY: generate-details
 
 ############################################################################
 ### Generate single high-level markdown file from Jinja template from OSCAL SSP
 ############################################################################
 generate-hl-ssp-markdown:
-	trestle author jinja -i templates/ssp_md_high_level_template.md.jinja -ssp acme_fedramp_demo_ssp -p fedramp_rev4_moderate -o acme_high_level_fedramp_demo_ssp.md
+	@source ./automation/trestle.sh && trestle author jinja -i templates/ssp_md_high_level_template.md.jinja -ssp acme_fedramp_demo_ssp -p fedramp_rev4_moderate -o acme_high_level_fedramp_demo_ssp.md
 .PHONY: generate-hl-ssp-markdown
 
 ############################################################################
 ### Run full workflow to populate FedRAMP docx template with high-level information
 ############################################################################
 generate-hl-ssp-word: generate-hl-ssp-markdown
-	pandoc acme_high_level_fedramp_demo_ssp.md --from markdown+table_captions+implicit_figures+rebase_relative_paths -t docx --reference-doc templates/FedRAMP-SSP-Moderate-Baseline-Template.docx -s --toc -o acme_high_level_fedramp_demo_ssp.docx
+	@source ./automation/trestle.sh && pandoc acme_high_level_fedramp_demo_ssp.md --from markdown+table_captions+implicit_figures+rebase_relative_paths -t docx --reference-doc templates/FedRAMP-SSP-Moderate-Baseline-Template.docx -s --toc -o acme_high_level_fedramp_demo_ssp.docx
 .PHONY: generate-hl-ssp-word

--- a/automation/mk/sanity.mk
+++ b/automation/mk/sanity.mk
@@ -6,7 +6,7 @@ sanity: sanity-catalogs sanity-profiles sanity-cd sanity-ssps
 .PHONY: sanity
 
 validate:
-	trestle validate -a
+	@source ./automation/trestle.sh && trestle validate -a
 .PHONY: validate
 
 sanity-catalogs: assemble-catalogs regenerate-catalogs

--- a/automation/regenerate.sh
+++ b/automation/regenerate.sh
@@ -2,6 +2,7 @@
 
 source ./automation/logging.sh
 source ./automation/transform.sh
+source ./automation/trestle.sh
 
 regenerate_catalogs() {
 catalogs=$(find ./catalogs -mindepth 1 -type d | wc -l)

--- a/automation/transform.sh
+++ b/automation/transform.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source ./automation/logging.sh
-
+source ./automation/trestle.sh
 
 transform_cac_ocp4_nist_high_oscal () {
   trestle task ocp4-cis-profile-to-oscal-cd -c adjunct-data/config-files/demo-ocp4-nist-high-profile-to-oscal-cd.config

--- a/automation/trestle.sh
+++ b/automation/trestle.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+TRESTLE_IMAGE="localhost:5000/trestle-demo"
+TRESTLE_IMAGE_TAG="latest"
+
+TRESTLE_CMD_IMAGE="trestle"
+PANDOC_CMD_IMAGE="/demo/bin/pandoc"
+PYTHON_CMD_IMAGE="python"
+
+CONTAINER_CMD=$(command -pv podman || command -pv docker)
+TRESTLE_IMAGE_EXISTS=$($CONTAINER_CMD image inspect $TRESTLE_IMAGE 2>/dev/null >/dev/null; echo $?)
+
+if [ "$TRESTLE_IMAGE_EXISTS" == "0" ];
+then
+  # the trestle image exists, use it by creating wrapper functions
+  function trestle {
+    ARGS=$@
+    CMD="$CONTAINER_CMD run -it --rm -w /demo/trestle-workspace -v $(pwd):/demo/trestle-workspace $TRESTLE_IMAGE:$TRESTLE_IMAGE_TAG $TRESTLE_CMD_IMAGE $@"
+    bash -c "$CMD"
+  }
+
+  function pandoc {
+    ARGS=$@
+    CMD="$CONTAINER_CMD run -it --rm -w /demo/trestle-workspace -v $(pwd):/demo/trestle-workspace $TRESTLE_IMAGE:$TRESTLE_IMAGE_TAG $PANDOC_CMD_IMAGE $@"
+    bash -c "$CMD"
+  }
+
+  function python {
+    ARGS=$@
+    CMD="$CONTAINER_CMD run -it --rm -w /demo/trestle-workspace -v $(pwd):/demo/trestle-workspace $TRESTLE_IMAGE:$TRESTLE_IMAGE_TAG $PYTHON_CMD_IMAGE $@"
+    bash -c "$CMD"
+  }
+fi

--- a/automation/validate.sh
+++ b/automation/validate.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source ./automation/logging.sh
+source ./automation/trestle.sh
 
 run_log 0 "Validating OSCAL content"
 trestle validate -a


### PR DESCRIPTION
Instead of having to run the container and setup github auth every time it is used, update scripts to check for the image. If image exists, create functions which will proxy a subset of commands to the container.

Therefore without any local 'trestle' install users can simply run:

```shell
make demo-build
make assemble
```

Commands that can use the image: trestle, pandoc, python