### PR TITLE
[ISSUE-62] adds workflow using trestlebot action for create component definition

### DIFF
--- a/.github/workflows/trestlebot-create-component-definition.yml
+++ b/.github/workflows/trestlebot-create-component-definition.yml
@@ -1,0 +1,53 @@
+name: Trestle-bot Create Component Definition
+
+on:
+  workflow_dispatch:
+   inputs:
+      profile_name:
+        description: Name of the Trestle profile to use for the component definition
+        required: true
+      component_definition_name:
+        description: Name of the component definition to create
+        required: true
+      component_title:
+        description: Name of the component to create in the generated component definition
+        required: true
+      component_type:
+        description: Type of the component (e.g. service, policy, physical, validation, etc.)
+        required: false
+        default: "service"
+      component_description:
+        description: Description of the component to create
+        required: true
+
+jobs:
+  create-component-definition:
+    name: Create component definition
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Create component definition and open pull request
+        id: generate-cd
+        uses: RedHatProductSecurity/trestle-bot/actions/create-cd@main
+        with:
+          profile_name: ${{ github.event.inputs.profile_name }}
+          component_definition_name: ${{ github.event.inputs.component_definition_name}}
+          component_title: ${{ github.event.inputs.component_title }}
+          component_type: ${{ github.event.inputs.component_type }}
+          component_description: ${{ github.event.inputs.component_description }}
+          markdown_path: "markdown/components"
+          branch: "create-component-definition-${{ github.run_id }}"
+          target_branch: "main"
+          file_pattern: "*.json,markdown/*,rules/*"
+          commit_user_name: "trestle-bot[bot]"
+          commit_user_email: "136850459+trestle-bot[bot]@users.noreply.github.com"
+          commit_message: "adds component  ${{ github.event.inputs.component_title }} in ${{ github.event.inputs.component_definition_name }}"
+          pull_request_title: "Add component ${{ github.event.inputs.component_title }} to ${{ github.event.inputs.component_definition_name }}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+          
+

--- a/.github/workflows/trestlebot-create-component-definition.yml
+++ b/.github/workflows/trestlebot-create-component-definition.yml
@@ -1,8 +1,9 @@
+---
 name: Trestle-bot Create Component Definition
 
 on:
   workflow_dispatch:
-   inputs:
+    inputs:
       profile_name:
         description: Name of the Trestle profile to use for the component definition
         required: true
@@ -29,7 +30,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Create component definition and open pull request
         id: generate-cd
         uses: RedHatProductSecurity/trestle-bot/actions/create-cd@main
@@ -43,11 +44,6 @@ jobs:
           branch: "create-component-definition-${{ github.run_id }}"
           target_branch: "main"
           file_pattern: "*.json,markdown/*,rules/*"
-          commit_user_name: "trestle-bot[bot]"
-          commit_user_email: "136850459+trestle-bot[bot]@users.noreply.github.com"
           commit_message: "adds component  ${{ github.event.inputs.component_title }} in ${{ github.event.inputs.component_definition_name }}"
           pull_request_title: "Add component ${{ github.event.inputs.component_title }} to ${{ github.event.inputs.component_definition_name }}"
           github_token: ${{ secrets.GITHUB_TOKEN }}
-
-          
-


### PR DESCRIPTION
Adding new GitHub workflow to use the Trestle-Bot the `create-cd` [action](https://github.com/RedHatProductSecurity/trestle-bot/tree/main/actions/create-cd).  This workflow is invoked using the `workflow_dispatch` trigger.  Upon successful completion the workflow will generate a new pull request containing the files for the created component definition.