### PR TITLE
[ISSUE-62] Add trestle-bot workflows for autosync catalogs and profiles

### DIFF
--- a/.github/workflows/trestlebot-autosync-catalog.yml
+++ b/.github/workflows/trestlebot-autosync-catalog.yml
@@ -1,0 +1,32 @@
+---
+name: Trestle-bot autosync catalog updates
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'catalogs/**'
+      - 'markdown/catalogs/**'
+
+jobs:
+  autosync:
+    name: Autosync catalog content
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Run autosync
+        id: autosync
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@main
+        with:
+          markdown_path: "markdown/catalogs"
+          oscal_model: "catalog"
+          file_pattern: "*.json,markdown/*"
+          branch: ${{ github.head_ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+ 

--- a/.github/workflows/trestlebot-autosync-catalog.yml
+++ b/.github/workflows/trestlebot-autosync-catalog.yml
@@ -28,5 +28,3 @@ jobs:
           oscal_model: "catalog"
           file_pattern: "*.json,markdown/*"
           branch: ${{ github.head_ref }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
- 

--- a/.github/workflows/trestlebot-autosync-profile.yml
+++ b/.github/workflows/trestlebot-autosync-profile.yml
@@ -1,0 +1,32 @@
+---
+name: Trestle-bot autosync profile updates
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'profiles/**'
+      - 'markdown/profiles/**'
+
+jobs:
+  autosync:
+    name: Autosync profile content
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Run autosync
+        id: autosync
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@main
+        with:
+          markdown_path: "markdown/profiles"
+          oscal_model: "profile"
+          file_pattern: "*.json,markdown/*"
+          branch: ${{ github.head_ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+ 

--- a/.github/workflows/trestlebot-autosync-profile.yml
+++ b/.github/workflows/trestlebot-autosync-profile.yml
@@ -28,5 +28,3 @@ jobs:
           oscal_model: "profile"
           file_pattern: "*.json,markdown/*"
           branch: ${{ github.head_ref }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
- 


### PR DESCRIPTION
This PR adds two new GitHub action workflows using the Trestle-Bot autosync command.  One is for syncing catalog content and the second is for syncing profile content.  These actions are executed upon a new pull request into the main branch.

Test runs:
- https://github.com/gvauter/trestle-demo-03/actions/runs/9208861130
- https://github.com/gvauter/trestle-demo-03/actions/runs/9208770264