### PR TITLE
[ISSUE-62] Addt trestle-bot rules-transform action and workflow

### DIFF
--- a/.github/actions/rules-transform/action.yml
+++ b/.github/actions/rules-transform/action.yml
@@ -1,0 +1,38 @@
+---
+name: rules-transform
+description: "Composite action for transforming rules with Trestle-bot"
+
+inputs:
+  dry-run:
+    required: false
+    description: "Run in dry run mode"
+    type: boolean
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            rules:
+              - 'rules/**'
+      - name: Transform
+        if: steps.changes.outputs.rules == 'true'
+        id: transform
+        uses: RedHatProductSecurity/trestle-bot/actions/rules-transform@main
+        with:
+          commit_message: "Auto-transform rules [skip ci]"
+          dry_run: ${{ inputs.dry-run }}
+      - name: Regenerate
+        if: steps.changes.outputs.rules == 'true'
+        id: regenerate
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@main
+        with:
+          markdown_path: "markdown"
+          oscal_model: "compdef"
+          commit_message: "Regenerate markdown content [skip ci]"
+          skip_assemble: true
+          dry_run: ${{ inputs.dry-run }}
+

--- a/.github/workflows/trestlebot-rules-transform.yml
+++ b/.github/workflows/trestlebot-rules-transform.yml
@@ -1,0 +1,52 @@
+---
+name: Trestle-bot rules-transform and autosync
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'profiles/**'
+      - 'catalogs/**'
+      - 'component-definitions/**'
+      - 'markdown/**'
+      - 'rules/**'
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  rules-transform:
+    name: Trestle-bot Rules Transform
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Transform rules
+        uses: ./.github/actions/rules-transform
+    
+  autosync:
+    name: Trestle-bot Autosync Content
+    needs: rules-transform
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Autosync component-definitions
+        id: autosync
+        uses: RedHatProductSecurity/trestle-bot/actions/autosync@main
+        with:
+          markdown_path: "markdown/components"
+          oscal_model: "compdef"
+          file_pattern: "*.json,markdown/*"
+          branch: ${{ github.head_ref }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trestlebot-rules-transform.yml
+++ b/.github/workflows/trestlebot-rules-transform.yml
@@ -49,4 +49,3 @@ jobs:
           oscal_model: "compdef"
           file_pattern: "*.json,markdown/*"
           branch: ${{ github.head_ref }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds new GitHub action and workflow for the Trestle-bot rules-transform task.  The new action checks for changes in the `rules/` directory and first runs the rules-transform task.  The autosync task runs after rules-transform has completed to avoid potential conflicts.

Successful use of new action and workflow: https://github.com/gvauter/trestle-demo-02/actions/runs/9317065652