### PR TITLE
fix: update trestlebot actions from TEMPLATES

### DIFF
--- a/.github/workflows/trestlebot-autosync-profile.yml
+++ b/.github/workflows/trestlebot-autosync-profile.yml
@@ -2,12 +2,16 @@
 name: Trestle-bot autosync profile updates
 
 on:
-  pull_request:
+  push:
     branches:
       - main
     paths:
       - 'profiles/**'
       - 'markdown/profiles/**'
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 jobs:
   autosync:
@@ -18,8 +22,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
       - name: Run autosync
         id: autosync
         uses: RedHatProductSecurity/trestle-bot/actions/autosync@main
@@ -27,4 +29,3 @@ jobs:
           markdown_path: "markdown/profiles"
           oscal_model: "profile"
           file_pattern: "*.json,markdown/*"
-          branch: ${{ github.head_ref }}

--- a/.github/workflows/trestlebot-autosync-ssp.yml
+++ b/.github/workflows/trestlebot-autosync-ssp.yml
@@ -1,13 +1,14 @@
----
-name: Trestle-bot autosync catalog updates
-
+name: Trestle-bot autosync ssp updates
 on:
   push:
     branches:
       - main
     paths:
+      - 'profiles/**'
       - 'catalogs/**'
-      - 'markdown/catalogs/**'
+      - 'component-definitions/**'
+      - 'system-security-plans/**'
+      - 'markdown/**'
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -15,7 +16,7 @@ concurrency:
 
 jobs:
   autosync:
-    name: Autosync catalog content
+    name: Autosync ssp content
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -26,6 +27,6 @@ jobs:
         id: autosync
         uses: RedHatProductSecurity/trestle-bot/actions/autosync@main
         with:
-          markdown_path: "markdown/catalogs"
-          oscal_model: "catalog"
+          markdown_path: "markdown/system-security-plans"
+          oscal_model: "ssp"
           file_pattern: "*.json,markdown/*"

--- a/.github/workflows/trestlebot-create-component-definition.yml
+++ b/.github/workflows/trestlebot-create-component-definition.yml
@@ -1,5 +1,5 @@
 ---
-name: Trestle-bot Create Component Definition
+name: Trestle-bot create component-definition
 
 on:
   workflow_dispatch:
@@ -40,7 +40,7 @@ jobs:
           component_title: ${{ github.event.inputs.component_title }}
           component_type: ${{ github.event.inputs.component_type }}
           component_description: ${{ github.event.inputs.component_description }}
-          markdown_path: "markdown/components"
+          markdown_path: "markdown/component-definitions"
           branch: "create-component-definition-${{ github.run_id }}"
           target_branch: "main"
           file_pattern: "*.json,markdown/*,rules/*"

--- a/.github/workflows/trestlebot-rules-transform.yml
+++ b/.github/workflows/trestlebot-rules-transform.yml
@@ -2,7 +2,7 @@
 name: Trestle-bot rules-transform and autosync
 
 on:
-  pull_request:
+  push:
     branches:
       - main
     paths:
@@ -17,35 +17,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  rules-transform:
-    name: Trestle-bot Rules Transform
+  rules-transform-and-autosync:
+    name: Rules Transform and AutoSync
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-      - name: Transform rules
-        uses: ./.github/actions/rules-transform
-    
-  autosync:
-    name: Trestle-bot Autosync Content
-    needs: rules-transform
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref }}
-      - name: Autosync component-definitions
+      - name: AutoSync
         id: autosync
         uses: RedHatProductSecurity/trestle-bot/actions/autosync@main
         with:
-          markdown_path: "markdown/components"
+          markdown_path: "markdown/component-definitions"
           oscal_model: "compdef"
           file_pattern: "*.json,markdown/*"
-          branch: ${{ github.head_ref }}
+      - name: Check if rules changed
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            rules:
+              - 'rules/**'
+      - name: Rules Transform
+        if: steps.changes.outputs.rules == 'true'
+        uses: RedHatProductSecurity/trestle-bot/actions/rules-transform@main
+        with:
+          markdown_path: "markdown/component-definitions"
+          commit_message: "Auto-transform rules [skip ci]"


### PR DESCRIPTION
Updating the GitHub workflows in this repo to use the latest versions from trestle-bot TEMPLATES.  These will now be maintained in this repository and the TEMPLATES in trestle-bot will be removed.  Documentation referencing the trestle-bot TEMPLATES folder will be updated to reference this repo.